### PR TITLE
Customize round 2

### DIFF
--- a/less/quotable.less
+++ b/less/quotable.less
@@ -139,7 +139,7 @@ canvas {
     background: @bg-color;
     margin: @line-height;
     position: relative;
-    padding: @padding * 2;
+    padding: 80px;
     font-size: @base-font-size * 5;
     line-height: 1 !important;
     overflow: hidden;
@@ -245,7 +245,7 @@ canvas {
         .quote& {
             .left-quote {
                 top: @padding;
-                left: @padding;
+                left: 80px;
             }
         }
 
@@ -279,8 +279,8 @@ canvas {
             content:@quote-begin-symbol;
             display: block;
             position: absolute;
-            top: @padding * 2;
-            left: @padding * 2;
+            top: 80px;
+            left: 80px;
             font-weight: @quote-font-weight;
             margin-left: @quote-mark-margin;
         }
@@ -363,7 +363,7 @@ canvas {
         width: 100%;
         z-index: 100;
         bottom: 0;
-        right: 0;
+        right: 20px;
         text-align: right;
         padding:  @padding @padding * 2 @padding * 2;
         margin: 0;

--- a/templates/waterbug.html
+++ b/templates/waterbug.html
@@ -60,6 +60,11 @@
                     <input type="text" class="form-control" id="source" name="source">
                 </div>
 
+                <div class="form-group">
+                  <label for="bottom-left-text">Optional Bottom Left Text</label>
+                  <input type="text" class="form-control" id="bottom-left-text" name="bottom-left-text">
+                </div>
+
                 <div class="row">
                     <div class="form-group col-lg-6">
                         <label for="crop">Crop</label>

--- a/www/js/waterbug-config.js
+++ b/www/js/waterbug-config.js
@@ -1,6 +1,6 @@
 // widths and padding
 var canvasWidth = 1024; // this will be the exported width of the image
-var elementPadding = 40; // padding around the logo and credit text
+var elementPadding = 60; // padding around the logo and credit text
 
 // logo configuration
 // the name of the logo object should match the value of the corresponding radio button in the HTML.

--- a/www/js/waterbug-config.js
+++ b/www/js/waterbug-config.js
@@ -63,14 +63,6 @@ var copyrightOptions = {
         source: 'AP',
         display: 'AP'
     },
-    'getty': {
-        showPhotographer: true,
-        showSource: false,
-        photographerRequired: false,
-        sourceRequired: false,
-        source: 'Getty Images',
-        display: 'Getty'
-    },
     'thirdParty': {
         showPhotographer: true,
         showSource: true,

--- a/www/js/waterbug-config.js
+++ b/www/js/waterbug-config.js
@@ -78,6 +78,14 @@ var copyrightOptions = {
         sourceRequired: true,
         source: 'Creative Commons',
         display: 'Creative Commons'
+    },
+    'other': {
+        showPhotographer: true,
+        showSource: false,
+        photographerRequired: false,
+        sourceRequired: false,
+        source: '',
+        display: 'Other'
     }
 }
 

--- a/www/js/waterbug.js
+++ b/www/js/waterbug.js
@@ -262,10 +262,18 @@ var buildCreditString = function() {
     var val = $copyrightHolder.val();
 
     if ($photographer.val() !== '') {
-        if (copyrightOptions[val]['source']) {
-            creditString = $photographer.val() + '/' + copyrightOptions[val]['source'];
+        if (copyrightOptions['freelance']) {
+          if (copyrightOptions[val]['source']) {
+            creditString = $photographer.val() + ' ' + copyrightOptions[val]['source'];
+          } else {
+              creditString = $photographer.val() + ' ' + $source.val();
+          }
         } else {
-            creditString = $photographer.val() + '/' + $source.val();
+          if (copyrightOptions[val]['source']) {
+              creditString = $photographer.val() + '/' + copyrightOptions[val]['source'];
+          } else {
+              creditString = $photographer.val() + '/' + $source.val();
+          }
         }
     } else {
         if (copyrightOptions[val]['source']) {

--- a/www/js/waterbug.js
+++ b/www/js/waterbug.js
@@ -31,7 +31,8 @@ var dx = 0;
 var image;
 var imageFilename = 'image';
 var currentCopyright;
-var credit = 'Belal Khan/Flickr'
+var credit = 'Belal Khan/Flickr';
+var bottomLeftText;
 var shallowImage = false;
 
 
@@ -44,6 +45,7 @@ var logo = new Image();
 var onDocumentLoad = function(e) {
     $source = $('#source');
     $photographer = $('#photographer');
+    $bottomLeftText = $('#bottom-left-text');
     $canvas = $('#imageCanvas');
     canvas = $canvas[0];
     $imageLoader = $('#imageLoader');
@@ -68,6 +70,7 @@ var onDocumentLoad = function(e) {
     logo.onload = renderCanvas;
 
     $photographer.on('keyup', renderCanvas);
+    $bottomLeftText.on('keyup', renderCanvas);
     $source.on('keyup', renderCanvas);
     $imageLoader.on('change', handleImage);
     $imageLinkButton.on('click', handleImageLink);
@@ -76,10 +79,11 @@ var onDocumentLoad = function(e) {
     $logoColor.on('change', onLogoColorChange);
     $crop.on('change', onCropChange);
     $canvas.on('mousedown touchstart', onDrag);
+    $bottomLeftText.on('change keyup', onBottomLeftTextChange);
     $copyrightHolder.on('change', onCopyrightChange);
     $customFilename.on('click', function(e) {
         e.stopPropagation();
-    })
+    });
 
     $("body").on("contextmenu", "canvas", function(e) {
         return false;
@@ -245,11 +249,19 @@ var renderCanvas = function() {
     }
 
     var creditWidth = ctx.measureText(credit);
-    ctx.fillText(
-        credit,
-        canvas.width - (creditWidth.width + elementPadding),
-        canvas.height - elementPadding
-    );
+      ctx.fillText(
+          credit,
+          canvas.width - (creditWidth.width + elementPadding),
+          canvas.height - elementPadding
+      );
+
+    if (bottomLeftText) {
+      ctx.fillText(
+          bottomLeftText,
+          elementPadding,
+          canvas.height - elementPadding
+      );
+    }
 
     validateForm();
 }
@@ -564,6 +576,12 @@ var onCropChange = function() {
         $dragHelp.hide();
     }
     renderCanvas();
+}
+
+var onBottomLeftTextChange = function() {
+  bottomLeftText = $bottomLeftText.val();
+
+  renderCanvas();
 }
 
 /*

--- a/www/js/waterbug.js
+++ b/www/js/waterbug.js
@@ -272,20 +272,21 @@ var renderCanvas = function() {
 var buildCreditString = function() {
     var creditString;
     var val = $copyrightHolder.val();
+    var separator;
 
     if ($photographer.val() !== '') {
-        if (copyrightOptions['freelance']) {
-          if (copyrightOptions[val]['source']) {
-            creditString = $photographer.val() + ' ' + copyrightOptions[val]['source'];
-          } else {
-              creditString = $photographer.val() + ' ' + $source.val();
-          }
+        if (copyrightOptions[val]['display'] === 'Freelance') {
+          separator = ' ';
+        } else if (copyrightOptions[val]['display'] === 'Other') {
+          separator = '';
         } else {
-          if (copyrightOptions[val]['source']) {
-              creditString = $photographer.val() + '/' + copyrightOptions[val]['source'];
-          } else {
-              creditString = $photographer.val() + '/' + $source.val();
-          }
+          separator = '/';
+        }
+
+        if (copyrightOptions[val]['source']) {
+          creditString = $photographer.val() + separator + copyrightOptions[val]['source'];
+        } else {
+          creditString = $photographer.val() + separator + $source.val();
         }
     } else {
         if (copyrightOptions[val]['source']) {


### PR DESCRIPTION
#### What's this PR do?

Adds some customizations to Lunchbox that editorial requested that would make wider adoption more likely.
#### Why are we doing this? How does it help us?

Helps us continue to customize Lunchbox to our needs so that it better fits into the editorial workflow. Gives us an optional extra text field for Waterbug where we can add things like hashtags to images.
#### How should this be manually tested?

Run the project locally
`fab app`

Go into Waterbug. In Waterbug, select the 'Other' option under 'Copyright holder'. See that there's one field option now in which you can type in whatever you want. See that there's no longer a 'Getty' option under 'Copyright holder' since we weren't using it. Try out using the 'Optional Bottom Left Text' to add hashtags to photos or any other additional text. See that it's not required to have something here, just a possibility. Trying using the 'Freelance' option under 'Copyright holder.' See that there's no forward slash between the photographer and their source there.

Go into Quotable. See that the margins around Quotable are increased. You can either compare with what's currently in Lunchbox or inspect element to see that it's 80px of padding.
#### Are there performance implications? If adding JS can it be done async? Do images/CSS/JS have cache headers set?
#### What are the relevant tickets?

Sprint task.
#### Next steps?
#### Smells?

Changed a few uses of the padding variable to 80px instead to accommodate the request that Quotable have more padding on its sides.
#### TODOs:
- [x] When clicking 'Save image' in Waterbug, the default should be to go to where the user last saved an image, not to Downloads each time
- [x] Increase the left margin on logo & quotes for Quotable for Twitter
- [x] Add a photo credit 'Other' field with one blank input field for increased flexibility
- [x] Remove Getty Image option
- [x] Add optional bottom-left corner blank input field to Waterbug for things like hashtags, etc.
- [x] Freelance image setting should lose the forward slash /
#### Has the relevant documentation/wiki been updated?
#### Technical debt note

Same
